### PR TITLE
Get delete flag functioning

### DIFF
--- a/assets/rsync.flags
+++ b/assets/rsync.flags
@@ -46,7 +46,7 @@
     --ignore-existing       skip updating files that exist on receiver
     --remove-source-files   sender removes synchronized files (non-dir)
     --del                   an alias for --delete-during
-    --delete                delete extraneous files from dest dirs
+-delete,    --delete                delete extraneous files from dest dirs
     --delete-before         receiver deletes before transfer (default)
     --delete-during         receiver deletes during xfer, not before
     --delete-delay          find deletions during, delete after

--- a/lib/websync/rsyncmetadata.js
+++ b/lib/websync/rsyncmetadata.js
@@ -41,7 +41,7 @@ function readFile(file, pattern, callback) {
     });
 }
 
-readFile(flagsFile, /^-(\w*),?\s+--([\w-]+)\s+(.+)/gm, function(matches) {
+readFile(flagsFile, /^-(\w+),?\s+--([\w-]+)\s+(.+)/gm, function(matches) {
     matches.forEach(function (m) {
         flags.push(new Flag(m[2], m[1], m[3]));
     });

--- a/lib/websync/rsyncmetadata.js
+++ b/lib/websync/rsyncmetadata.js
@@ -41,7 +41,7 @@ function readFile(file, pattern, callback) {
     });
 }
 
-readFile(flagsFile, /^-(\w),?\s+--([\w-]+)\s+(.+)/gm, function(matches) {
+readFile(flagsFile, /^-(\w*),?\s+--([\w-]+)\s+(.+)/gm, function(matches) {
     matches.forEach(function (m) {
         flags.push(new Flag(m[2], m[1], m[3]));
     });


### PR DESCRIPTION
https://github.com/mattijs/node-rsync/blob/master/rsync.js
Rsync has a short option defined for delete on line 587.

Changed the regex so it will read multiple characters for the first group and added a -delete in the flags file so it will get picked up.